### PR TITLE
Ignore tags which are not valid version numbers.

### DIFF
--- a/lib/vim-flavor/flavor.rb
+++ b/lib/vim-flavor/flavor.rb
@@ -106,7 +106,7 @@ module Vim
 
         tags.
           split(/[\r\n]/).
-          select {|t| t != ''}.
+          select {|t| t != '' && Gem::Version.correct?(t)}.
           map {|t| Gem::Version.create(t)}
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,7 @@ def create_a_test_repo(path)
         git commit -am 'Update foo'
         git tag -a -m "Version $version" "$version"
       done
+      git tag -a -m "A non-version tag" "something-non-version-y"
     } >/dev/null
   END
 end


### PR DESCRIPTION
This lets repos use tags for things other than versioning without breaking
vim-flavor.
