### PR TITLE
Make thor a runtime dependency.

### DIFF
--- a/vim-flavor.gemspec
+++ b/vim-flavor.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = Vim::Flavor::VERSION
 
+  gem.add_dependency('thor', '~> 0.14.6')
+
   gem.add_development_dependency('rspec', '~> 2.8')
-  gem.add_development_dependency('thor', '~> 0.14.6')
 end


### PR DESCRIPTION
Thor is required to use the vim-flavor command.  Therefore, thor should
be a runtime dependency.
