### PR TITLE
Don't require Bundler

### DIFF
--- a/lib/vim-flavor.rb
+++ b/lib/vim-flavor.rb
@@ -1,4 +1,3 @@
-require 'bundler/setup'
 require 'vim-flavor/enumerableextension'
 
 module Vim


### PR DESCRIPTION
Vim-flavor doesn't depend on Bundler (like no other gems do), so it
shouldn't require it. Bundler should only be required by users of the
gem, if they need it.
