### PR TITLE
Use bash -c to execute shells

### DIFF
--- a/lib/vim-flavor/facade.rb
+++ b/lib/vim-flavor/facade.rb
@@ -46,7 +46,7 @@ module Vim
           %Q{ '#{runner}' \
               #{runtime_paths.flat_map {|p| ['-d', p]}.shelljoin} \
               #{files_or_dirs.shelljoin} }
-        succeeded = system(command)
+        succeeded = system('bash', '-c', command)
         exit(1) unless succeeded
       end
 

--- a/lib/vim-flavor/flavor.rb
+++ b/lib/vim-flavor/flavor.rb
@@ -25,7 +25,7 @@ module Vim
       end
 
       def cached_version?(version)
-        system <<-"END"
+        system 'bash', '-c', <<-"END"
           {
             cd '#{cached_repo_path}' &&
             git rev-list --quiet '#{version.to_revision}' --

--- a/lib/vim-flavor/shellutility.rb
+++ b/lib/vim-flavor/shellutility.rb
@@ -2,7 +2,8 @@ module Vim
   module Flavor
     module ShellUtility
       def sh script
-        output = send(:`, script)
+        output = IO.popen(['bash', '-c', script], 'r', &:read)
+
         if $? == 0
           output
         else


### PR DESCRIPTION
This allows shell invocations to work when vim-flavor isn't run from a
bash shell.

I encountered this when trying to run `vim-flavor install` on an appveyor build and getting a syntax error: https://ci.appveyor.com/project/alexgenco/neovim-ruby/build/262/job/cfp9ulad6vy9y7cc#L143. 

I'm having a hard time running the test suite, when I run `rake test` it fails with ```undefined method `all' for module `Aruba::Matchers' (NameError)```. Have you seen this before?