### PR TITLE
Remove deprecated usage of .exists? style methods

### DIFF
--- a/lib/vim-flavor/flavor.rb
+++ b/lib/vim-flavor/flavor.rb
@@ -21,7 +21,7 @@ module Vim
 
       # Return true if this flavor's repository is already cloned.
       def cached?
-        Dir.exists?(cached_repo_path)
+        Dir.exist?(cached_repo_path)
       end
 
       def cached_version?(version)

--- a/lib/vim-flavor/flavorfile.rb
+++ b/lib/vim-flavor/flavorfile.rb
@@ -18,7 +18,7 @@ module Vim
 
       def self.load_or_new(flavorfile_path)
         ff = new()
-        ff.load(flavorfile_path) if FileTest.exists?(flavorfile_path)
+        ff.load(flavorfile_path) if FileTest.exist?(flavorfile_path)
         ff
       end
 
@@ -33,12 +33,12 @@ module Vim
         new_path = Pathname.new(flavorfile_path).relative_path_from(Pathname.getwd())
         old_path = new_path.dirname() / 'VimFlavor'
 
-        path = if FileTest.exists?(new_path)
-          if warn and FileTest.exists?(old_path)
+        path = if FileTest.exist?(new_path)
+          if warn and FileTest.exist?(old_path)
             Console::warn "Delete #{old_path}.  #{new_path} is being read instead."
           end
           new_path
-        elsif FileTest.exists?(old_path)
+        elsif FileTest.exist?(old_path)
           if warn
             Console::warn "Rename #{old_path} to #{new_path}.  #{old_path} wll be ignored in future version."
           end

--- a/lib/vim-flavor/lockfile.rb
+++ b/lib/vim-flavor/lockfile.rb
@@ -5,7 +5,7 @@ module Vim
     class LockFile
       def self.load_or_new(lockfile_path)
         l = new(lockfile_path)
-        l.load() if File.exists?(lockfile_path)
+        l.load() if File.exist?(lockfile_path)
         l
       end
 
@@ -14,7 +14,7 @@ module Vim
         new_path = Pathname.new(lockfile_path).relative_path_from(Pathname.getwd())
         old_path = new_path.dirname() / 'VimFlavor.lock'
 
-        if error and FileTest.exists?(old_path)
+        if error and FileTest.exist?(old_path)
           Console::error "#{old_path} is no longer used.  Rename it to #{new_path}."
         end
 


### PR DESCRIPTION
This includes `File.exists?`, `FileTest.exists?`, and `Dir.exists?`.
These are deprecated and have been removed in Ruby 3.2